### PR TITLE
Add Job as top-level actor that a user interacts with

### DIFF
--- a/examples/process-array/process-array.pony
+++ b/examples/process-array/process-array.pony
@@ -5,10 +5,11 @@ use fj = "../../fork_join"
 actor Main
   new create(env: Env) =>
     let array: Array[U8] iso = recover iso [ 201;202;3;4;5;6;7;8;9;10 ] end
-    fj.Coordinator[Array[U8] iso, USize](
+    let job = fj.Job[Array[U8] iso, USize](
       WorkerBuilder,
       Generator(consume array),
       AddingCollector(env.out))
+    job.start()
 
 class WorkerBuilder is fj.WorkerBuilder[Array[U8] iso, USize]
   fun ref apply(): fj.Worker[Array[U8] iso, USize] iso^ =>

--- a/examples/random-number-to-string/random-number-to-string.pony
+++ b/examples/random-number-to-string/random-number-to-string.pony
@@ -5,10 +5,11 @@ use "random"
 
 actor Main
   new create(env: Env) =>
-    fj.Coordinator[USize, String](
+    let job = fj.Job[USize, String](
       WorkerBuilder,
       Generator,
       StringCollector(env.out))
+    job.start()
 
 class WorkerBuilder is fj.WorkerBuilder[USize, String]
   fun ref apply(): fj.Worker[USize, String] iso^ =>

--- a/examples/word-count/word-count.pony
+++ b/examples/word-count/word-count.pony
@@ -13,10 +13,11 @@ actor Main
       let fp = FilePath(env.root as AmbientAuth, env.args(1)?, caps)
       let file = recover iso OpenFile(fp) as File end
 
-      fj.Coordinator[String, WordCounts iso](
+      let job = fj.Job[String, WordCounts iso](
         WorkerBuilder,
         FileReader(consume file),
         WordCountTotaler(env.out))
+      job.start()
     else
       env.exitcode(-1)
       env.err.print("Error during setup.")

--- a/fork_join/_status.pony
+++ b/fork_join/_status.pony
@@ -1,0 +1,3 @@
+primitive _Started
+primitive _Terminating
+primitive _NotYetStarted

--- a/fork_join/_test_collector_terminate.pony
+++ b/fork_join/_test_collector_terminate.pony
@@ -22,10 +22,12 @@ class iso _TestCollectorTerminate is UnitTest
     h.long_test(1_000_000_000)
     h.expect_action("collector.finish()")
 
-    Coordinator[U8, U8](
+    let job = Job[U8, U8](
       _CollectorTerminateBuilder,
       _CollectorTerminateGenerator,
       _CollectorTerminateCollector(h))
+
+    job.start()
 
 class _CollectorTerminateBuilder is WorkerBuilder[U8, U8]
   fun ref apply(): Worker[U8, U8] iso^ =>

--- a/fork_join/_test_end_to_end.pony
+++ b/fork_join/_test_end_to_end.pony
@@ -17,10 +17,12 @@ class iso _TestEndToEnd is UnitTest
     let expected: Array[U8] val = recover val [1;3;5;7;9;57;4;3;2;1;88;18] end
     let input: Array[U8] iso = recover iso expected.clone() end
 
-    Coordinator[Array[U8] iso, Array[U8] val](
+    let job = Job[Array[U8] iso, Array[U8] val](
       _EndToEndBuilder,
       _EndToEndGenerator(consume input),
       _EndToEndCollector(h, expected))
+
+    job.start()
 
 class _EndToEndBuilder is WorkerBuilder[Array[U8] iso, Array[U8] val]
   fun ref apply(): Worker[Array[U8] iso, Array[U8] val] iso^ =>

--- a/fork_join/collector_runner.pony
+++ b/fork_join/collector_runner.pony
@@ -1,11 +1,11 @@
 // TODO: top level documentation
 actor CollectorRunner[Input: Any #send, Output: Any #send]
   var _terminating: Bool = false
-  let _coordinator: Coordinator[Input, Output]
+  let _coordinator: _Coordinator[Input, Output]
   let _collector: Collector[Input, Output]
 
   new create(collector: Collector[Input, Output] iso,
-    coordinator: Coordinator[Input, Output])
+    coordinator: _Coordinator[Input, Output])
   =>
     _collector = consume collector
     _coordinator = coordinator

--- a/fork_join/job.pony
+++ b/fork_join/job.pony
@@ -1,0 +1,34 @@
+// TODO: top-level documentation
+actor Job[Input: Any #send, Output: Any #send]
+  var _status: _JobStatus = _NotYetStarted
+  let _coordinator: _Coordinator[Input, Output]
+
+  new create(worker_builder: WorkerBuilder[Input, Output] iso,
+    generator: Generator[Input] iso,
+    collector: Collector[Input, Output] iso,
+    max_workers: USize = 0)
+  =>
+    _coordinator = _Coordinator[Input, Output](consume worker_builder,
+      consume generator,
+      consume collector,
+      max_workers)
+
+  be start() =>
+    """
+    Start the job.
+    """
+    if _status is _NotYetStarted then
+      _status = _Started
+      _coordinator._start()
+    end
+
+  be terminate() =>
+    """
+    End the job before the generator has run out of data.
+    """
+    if _status is _Terminating then
+      _status = _Terminating
+      _coordinator._terminate()
+    end
+
+type _JobStatus is (_Started | _Terminating | _NotYetStarted)

--- a/fork_join/worker_runner.pony
+++ b/fork_join/worker_runner.pony
@@ -1,12 +1,12 @@
 // TODO: needs class level documentation
 actor WorkerRunner[Input: Any #send, Output: Any #send]
-  let _coordinator: Coordinator[Input, Output]
+  let _coordinator: _Coordinator[Input, Output]
   let _collector: CollectorRunner[Input, Output]
   let _notify: Worker[Input, Output]
   var _running: Bool = false
   var _early_termination_requested: Bool = false
 
-  new create(coordinator: Coordinator[Input, Output],
+  new create(coordinator: _Coordinator[Input, Output],
     collector: CollectorRunner[Input, Output],
     notify: Worker[Input, Output] iso)
   =>


### PR DESCRIPTION
Coordinator is now _Coordinator and no longer exposed to the fork/join
end-user. Having "Job" be the primary interface that users interact
with will make writing documentation easier as explaining what the
Coordinator did from an end-user perspective was a little odd as it
did "many things". It still does a few different things but that
will be further broken down.

This is an initial first step, I'm going to move all the creation
of actors that the Coordinator currently does into the Job.