### PR TITLE
Add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: announce-a-release
 
+permissions:
+  packages: read
+  contents: write
+
 jobs:
   announce:
     name: Announcements

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -5,6 +5,9 @@ on:
     types:
       - shared-docker-builders-updated
 
+permissions:
+  packages: read
+
 jobs:
   vs-ponyc-latest:
     name: Test against ponyc main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  packages: read
+
 jobs:
   superlinter:
     name: Lint bash, docker, markdown, and yaml

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: prepare-for-a-release
 
+permissions:
+  packages: read
+  contents: write
+
 jobs:
   # all tasks that need to be done before we add an X.Y.Z tag
   # should be done as a step in the pre-tagging job.


### PR DESCRIPTION
Adds explicit permissions blocks to workflows that were missing them, matching the standard permissions used across ponylang projects.