### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/word-count/word-count.pony
+++ b/examples/word-count/word-count.pony
@@ -77,7 +77,7 @@ class WordCountTotaler is fj.Collector[String, WordCounts iso]
   fun ref collect(runner: fj.CollectorRunner[String, WordCounts iso] ref,
     result: WordCounts iso)
   =>
-    match _counts
+    match \exhaustive\ _counts
     | None =>
       // We haven't gotten any counts yet, instead of copying the map, let's
       // just keep the first one as our base to build upon
@@ -91,7 +91,7 @@ class WordCountTotaler is fj.Collector[String, WordCounts iso]
     end
 
   fun ref finish() =>
-    match _counts
+    match \exhaustive\ _counts
     | None =>
       _out.print("No words counted.")
     | let counts: WordCounts =>


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.